### PR TITLE
Update nginx.conf.tmpl

### DIFF
--- a/nginx-skydns/nginx.conf.tmpl
+++ b/nginx-skydns/nginx.conf.tmpl
@@ -114,7 +114,7 @@ server {
            #
            # Custom headers and headers various browsers *should* be OK with but aren't
            #
-           add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,twnel-app-key,twnel-app-token,apikey,apitoken,worldwide,requester,numbers';
+           add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,twnel-app-key,twnel-app-token,apikey,apitoken,worldwide,requester,numbers,responsetype';
            #
            # Tell client that this pre-flight info is valid for 20 days
            #
@@ -140,7 +140,7 @@ server {
            #
            # Custom headers and headers various browsers *should* be OK with but aren't
            #
-           add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,twnel-app-key,twnel-app-token,apikey,apitoken,worldwide,requester,numbers';
+           add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,twnel-app-key,twnel-app-token,apikey,apitoken,worldwide,requester,numbers,responsetype';
            #
            # Tell client that this pre-flight info is valid for 20 days
            #


### PR DESCRIPTION
XMLHttpRequest cannot load https://api.twnel.net/v1.3/conversations?worldwide=true&requester=%2B573005574311&per_page=250&page=1&exposure=pending&exposure=active&exposure=interrupted. Request header field responsetype is not allowed by Access-Control-Allow-Headers.
