### PR TITLE
Update nginx.conf.tmpl

### DIFF
--- a/nginx-skydns/nginx.conf.tmpl
+++ b/nginx-skydns/nginx.conf.tmpl
@@ -102,7 +102,7 @@ server {
     location ^~ /.well-known {
         allow all;
         auth_basic off;
-        alias /etc/nginx/certs/.well-known/;
+        alias /etc/nginx/letscerts/.well-known/;
     }
 
     #


### PR DESCRIPTION
/etc/nginx/certs is being used by kube as read-only